### PR TITLE
Update color theme in VSCode settings to Visual Studio 2017 Dark - C++

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         "debug.overrideEngine": "copilot-chat",
         "debug.useNodeFetcher": true
     },
-    "workbench.colorTheme": "Default Dark+",
+    "workbench.colorTheme": "Abyss",
     "editor.wordWrap": "on",
     "files.autoSave": "afterDelay",
     "editor.suggestOnTriggerCharacters": true,


### PR DESCRIPTION
This pull request updates the Visual Studio Code settings to change the color theme used in the editor.

